### PR TITLE
モデルの作成日時と更新日時を正しく反映されるように修正

### DIFF
--- a/kokemomo/plugins/blog/model/km_blog_article.py
+++ b/kokemomo/plugins/blog/model/km_blog_article.py
@@ -28,8 +28,8 @@ class KMBlogArticle(Base):
     title = Column(Text)
     article = Column(Text)
     post_date = Column(DateTime)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_category.py
+++ b/kokemomo/plugins/blog/model/km_blog_category.py
@@ -22,8 +22,8 @@ class KMBlogCategory(Base):
     id = Column(Integer, autoincrement=True, primary_key=True)
     info_id = Column(Integer)
     name = Column(Text)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_comment.py
+++ b/kokemomo/plugins/blog/model/km_blog_comment.py
@@ -22,8 +22,8 @@ class KMBlogComment(Base):
     id = Column(Integer, autoincrement=True, primary_key=True)
     article_id = Column(Integer)
     comment = Column(Text)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_info.py
+++ b/kokemomo/plugins/blog/model/km_blog_info.py
@@ -23,8 +23,8 @@ class KMBlogInfo(Base):
     name = Column(Text)
     url = Column(Text)
     description = Column(Text)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_subscription.py
+++ b/kokemomo/plugins/blog/model/km_blog_subscription.py
@@ -21,8 +21,8 @@ class KMBlogSubscription(Base):
     id = Column(Integer, autoincrement=True, primary_key=True)
     user_id = Column(Integer)
     target_id = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_group_table.py
+++ b/kokemomo/plugins/engine/model/km_group_table.py
@@ -34,8 +34,8 @@ class KMGroup(Base):
     id = Column(Integer, autoincrement=True, primary_key=True)
     name = Column(String(50))
     parent_id = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_parameter_table.py
+++ b/kokemomo/plugins/engine/model/km_parameter_table.py
@@ -33,8 +33,8 @@ class KMParameter(Base):
     id = Column(Integer, autoincrement=True, primary_key=True)
     key = Column(String(50))
     json = Column(Text())
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_role_table.py
+++ b/kokemomo/plugins/engine/model/km_role_table.py
@@ -37,8 +37,8 @@ class KMRole(Base):
     name = Column(String(50))
     target = Column(String(100))
     is_allow = Column(Boolean)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_user_table.py
+++ b/kokemomo/plugins/engine/model/km_user_table.py
@@ -42,8 +42,8 @@ class KMUser(Base):
     mail_address = Column(String(254))
     group_id = Column(Integer)
     role_id = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/recommend/model/km_history_table.py
+++ b/kokemomo/plugins/recommend/model/km_history_table.py
@@ -37,8 +37,8 @@ class KMHistory(Base):
     user_id = Column(String(10))
     contents = Column(Text())
     count = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
-    update_at = Column(DateTime, default=datetime.datetime.now(), onupdate=datetime.datetime.now())
+    create_at = Column(DateTime, default=datetime.datetime.now)
+    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     def __repr__(self):
         return create_repr_str(self)


### PR DESCRIPTION
1. `now()`を渡してしまうと静的な値になってしまうため、時刻が正しく反映されていません。`now`とすることで関数オブジェクトになるため、モデルインスタンスの作成時＆更新時に値が正しく入ります。
2. `create_at`カラムは`onupdate`時に更新すると本来の意味をなさなくなってしまうため`onupdate`の項目を削除しました。

レビューよろしくお願いします:pray: