### PR TITLE
型の検査に`isinstance`関数を使用するように変更

### DIFF
--- a/kokemomo/plugins/engine/utils/km_model_utils.py
+++ b/kokemomo/plugins/engine/utils/km_model_utils.py
@@ -22,7 +22,7 @@ def create_repr_str(model):
     for column in model.__table__.c:
         value = getattr(model, column.name)
         if value is None:
-            if type(value) is unicode:
+            if isinstance(value, unicode):
                 value = value.encode(charset)
             value = ''
         result += (column.name + '="' + str(value) + '",')
@@ -34,7 +34,7 @@ def create_json(model):
     for column in model.__table__.c:
         value = getattr(model, column.name)
         if value is not None:
-            if type(value) is unicode:
+            if isinstance(value, unicode):
                 value = value.encode(charset)
             try:
                 # json形式の値の場合はダブルクォートをつけない


### PR DESCRIPTION
Pythonのドキュメントに以下の記述があったので、修正しておいてもよいかなと思いました。

> オブジェクトの型の検査には `isinstance()`組み込み関数を使うことが推奨されます。

http://docs.python.jp/2.7/library/functions.html

小さな変更で申し訳ありませんがレビューよろしくお願いします:bow:

