### PR TITLE
抽象度を上げたデータベースマネージャーを実装する

### DIFF
--- a/kokemomo/__init__.py
+++ b/kokemomo/__init__.py
@@ -14,9 +14,9 @@ from kokemomo.plugins import blog
 import application
 from beaker.middleware import SessionMiddleware
 from kokemomo.plugins.engine.controller.km_plugin_manager import mount, run, get_root_plugin, set_root_plugin
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
-db.init()
+storage.init()
 
 # session config
 session_opts = {

--- a/kokemomo/__init__.py
+++ b/kokemomo/__init__.py
@@ -14,6 +14,9 @@ from kokemomo.plugins import blog
 import application
 from beaker.middleware import SessionMiddleware
 from kokemomo.plugins.engine.controller.km_plugin_manager import mount, run, get_root_plugin, set_root_plugin
+from kokemomo.plugins.engine.controller.km_storage import db
+
+db.init()
 
 # session config
 session_opts = {

--- a/kokemomo/plugins/admin/controller/km_admin.py
+++ b/kokemomo/plugins/admin/controller/km_admin.py
@@ -7,7 +7,6 @@ from kokemomo.plugins.engine.controller.km_plugin_manager import KMBaseControlle
 from kokemomo.plugins.engine.controller.km_exception import log
 from kokemomo.plugins.engine.controller.km_login import logout, login_auth
 
-from kokemomo.plugins.engine.controller.km_db_manager import *
 from kokemomo.plugins.engine.controller.km_session_manager import get_value_to_session
 from kokemomo.plugins.engine.model.km_user_table import find_all as user_find_all, delete as user_delete, update as user_update, KMUser
 from kokemomo.plugins.engine.model.km_group_table import find_all as group_find_all, delete as group_delete, update as group_update, KMGroup
@@ -24,7 +23,7 @@ __author__ = 'hiroki-m'
 
 DATA_DIR_PATH = "./kokemomo/data/test/"# TODO: 実行する場所によって変わる為、外部ファイルでHOMEを定義するような仕組みへ修正する
 charset = get_character_set_setting()
-db_manager = KMDBManager("engine")
+from kokemomo.plugins.engine.controller.km_storage import db
 
 
 class KMAdmin(KMBaseController):
@@ -113,7 +112,7 @@ class KMAdmin(KMBaseController):
 
     @log
     def login_auth(self):
-        return login_auth(self.data, db_manager)
+        return login_auth(self.data, db)
 
 
     def logout(self):
@@ -129,7 +128,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             for save_user in self.data.get_request().forms:
                 json_data = json.loads(save_user.decode(charset))
                 for id in json_data:
@@ -154,7 +153,7 @@ class KMAdmin(KMBaseController):
         :return: users.
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             result = user_find_all(session)
         finally:
             session.close()
@@ -169,7 +168,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             for save_group in self.data.get_request().forms:
                 json_data = json.loads(save_group.decode(charset))
                 for id in json_data:
@@ -190,7 +189,7 @@ class KMAdmin(KMBaseController):
         :return: groups.
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             result = group_find_all(session)
         finally:
             session.close()
@@ -206,7 +205,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             for save_group in self.data.get_request().forms:
                 json_data = json.loads(save_group.decode(charset))
                 for id in json_data:
@@ -231,7 +230,7 @@ class KMAdmin(KMBaseController):
         :return: roles.
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             result = role_find_all(session)
         finally:
             session.close()
@@ -247,7 +246,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             for save_params in self.data.get_request().forms:
                 json_data = json.loads(save_params.decode(charset))
                 for key in json_data:
@@ -268,7 +267,7 @@ class KMAdmin(KMBaseController):
         :return: parameters.
         """
         try:
-            session = db_manager.get_session()
+            session = db.adapter.session
             result = find_parameter(session)
         finally:
             session.commit()

--- a/kokemomo/plugins/admin/controller/km_admin.py
+++ b/kokemomo/plugins/admin/controller/km_admin.py
@@ -23,7 +23,7 @@ __author__ = 'hiroki-m'
 
 DATA_DIR_PATH = "./kokemomo/data/test/"# TODO: 実行する場所によって変わる為、外部ファイルでHOMEを定義するような仕組みへ修正する
 charset = get_character_set_setting()
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 
 class KMAdmin(KMBaseController):
@@ -112,7 +112,7 @@ class KMAdmin(KMBaseController):
 
     @log
     def login_auth(self):
-        return login_auth(self.data, db)
+        return login_auth(self.data, storage)
 
 
     def logout(self):
@@ -128,7 +128,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             for save_user in self.data.get_request().forms:
                 json_data = json.loads(save_user.decode(charset))
                 for id in json_data:
@@ -153,7 +153,7 @@ class KMAdmin(KMBaseController):
         :return: users.
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             result = user_find_all(session)
         finally:
             session.close()
@@ -168,7 +168,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             for save_group in self.data.get_request().forms:
                 json_data = json.loads(save_group.decode(charset))
                 for id in json_data:
@@ -189,7 +189,7 @@ class KMAdmin(KMBaseController):
         :return: groups.
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             result = group_find_all(session)
         finally:
             session.close()
@@ -205,7 +205,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             for save_group in self.data.get_request().forms:
                 json_data = json.loads(save_group.decode(charset))
                 for id in json_data:
@@ -230,7 +230,7 @@ class KMAdmin(KMBaseController):
         :return: roles.
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             result = role_find_all(session)
         finally:
             session.close()
@@ -246,7 +246,7 @@ class KMAdmin(KMBaseController):
 
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             for save_params in self.data.get_request().forms:
                 json_data = json.loads(save_params.decode(charset))
                 for key in json_data:
@@ -267,7 +267,7 @@ class KMAdmin(KMBaseController):
         :return: parameters.
         """
         try:
-            session = db.adapter.session
+            session = storage.adapter.session
             result = find_parameter(session)
         finally:
             session.commit()

--- a/kokemomo/plugins/blog/controller/km_blog.py
+++ b/kokemomo/plugins/blog/controller/km_blog.py
@@ -6,7 +6,6 @@ __author__ = 'hiroki-m'
 import os
 
 from kokemomo.lib.bottle import template, route, static_file, url, request, response, redirect
-from kokemomo.plugins.engine.controller.km_db_manager import *
 from kokemomo.plugins.engine.controller.km_session_manager import get_value_to_session
 from kokemomo.plugins.engine.utils.km_utils import get_menu_list
 from kokemomo.plugins.engine.utils.km_config import get_character_set_setting
@@ -32,7 +31,7 @@ from kokemomo.plugins.blog.model.km_blog_comment import KMBlogComment, update as
 
 DATA_DIR_PATH = "/kokemomo/data/blog/"
 
-db_manager = KMDBManager("engine")
+from kokemomo.plugins.engine.controller.km_storage import db
 
 charset = get_character_set_setting()
 
@@ -102,7 +101,7 @@ def blog_admin():
     :return: template
     '''
     try:
-        session = db_manager.get_session()
+        session = db.adapter.session
         type = request.params.get('type', default='dashboard')
         id = request.params.get('id', default='None')
         if request.params.get('delete', default=False):
@@ -159,7 +158,7 @@ def blog_admin_create_info():
     :return:
     '''
     try:
-        session = db_manager.get_session()
+        session = db.adapter.session
         values = create_info_values(request, session)
         if len(values['errors']) == 0:
             save_info(values['info'], session)
@@ -201,7 +200,7 @@ def blog_admin_create_category():
     :return:
     '''
     try:
-        session = db_manager.get_session()
+        session = db.adapter.session
         values = create_category_values(request, session)
         if len(values['errors']) == 0:
             save_category(values['category'], session)
@@ -240,7 +239,7 @@ def blog_admin_create_article():
     :return:
     '''
     try:
-        session = db_manager.get_session()
+        session = db.adapter.session
         values = create_article_values(request, session)
         if len(values['errors']) == 0:
             save_article(values['article'], session)
@@ -286,7 +285,7 @@ Templates
 @route('/blog/<blog_url>')
 def blog_page(blog_url):
     try:
-        session = db_manager.get_session()
+        session = db.adapter.session
         info = find_info_by_url(blog_url, session)
         info.articles = find_article_list_by_info_id(info.id, session)
         for article in info.articles:
@@ -310,7 +309,7 @@ def blog_entry_css_static(filename):
 @route('/blog/<blog_url>/add_comment', method='POST')
 def blog_add_comment(blog_url):
     try:
-        session = db_manager.get_session()
+        session = db.adapter.session
         blob_comment = KMBlogComment()
         article_id = request.params.get('id', default='None')
         comment = request.params.get('comment', default='').decode(charset)

--- a/kokemomo/plugins/blog/controller/km_blog.py
+++ b/kokemomo/plugins/blog/controller/km_blog.py
@@ -31,7 +31,7 @@ from kokemomo.plugins.blog.model.km_blog_comment import KMBlogComment, update as
 
 DATA_DIR_PATH = "/kokemomo/data/blog/"
 
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 charset = get_character_set_setting()
 
@@ -101,7 +101,7 @@ def blog_admin():
     :return: template
     '''
     try:
-        session = db.adapter.session
+        session = storage.adapter.session
         type = request.params.get('type', default='dashboard')
         id = request.params.get('id', default='None')
         if request.params.get('delete', default=False):
@@ -158,7 +158,7 @@ def blog_admin_create_info():
     :return:
     '''
     try:
-        session = db.adapter.session
+        session = storage.adapter.session
         values = create_info_values(request, session)
         if len(values['errors']) == 0:
             save_info(values['info'], session)
@@ -200,7 +200,7 @@ def blog_admin_create_category():
     :return:
     '''
     try:
-        session = db.adapter.session
+        session = storage.adapter.session
         values = create_category_values(request, session)
         if len(values['errors']) == 0:
             save_category(values['category'], session)
@@ -239,7 +239,7 @@ def blog_admin_create_article():
     :return:
     '''
     try:
-        session = db.adapter.session
+        session = storage.adapter.session
         values = create_article_values(request, session)
         if len(values['errors']) == 0:
             save_article(values['article'], session)
@@ -285,7 +285,7 @@ Templates
 @route('/blog/<blog_url>')
 def blog_page(blog_url):
     try:
-        session = db.adapter.session
+        session = storage.adapter.session
         info = find_info_by_url(blog_url, session)
         info.articles = find_article_list_by_info_id(info.id, session)
         for article in info.articles:
@@ -309,7 +309,7 @@ def blog_entry_css_static(filename):
 @route('/blog/<blog_url>/add_comment', method='POST')
 def blog_add_comment(blog_url):
     try:
-        session = db.adapter.session
+        session = storage.adapter.session
         blob_comment = KMBlogComment()
         article_id = request.params.get('id', default='None')
         comment = request.params.get('comment', default='').decode(charset)

--- a/kokemomo/plugins/blog/model/km_blog_article.py
+++ b/kokemomo/plugins/blog/model/km_blog_article.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 __author__ = 'hiroki'
 
@@ -20,14 +20,14 @@ It is blog article table to be used in the KOKEMOMO.
 """
 
 
-class KMBlogArticle(db.Model):
+class KMBlogArticle(storage.Model):
     __tablename__ = 'km_blog_article'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    info_id = db.Column(db.Integer)
-    category_id = db.Column(db.Integer)
-    title = db.Column(db.Text)
-    article = db.Column(db.Text)
-    post_date = db.Column(db.DateTime)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    info_id = storage.Column(storage.Integer)
+    category_id = storage.Column(storage.Integer)
+    title = storage.Column(storage.Text)
+    article = storage.Column(storage.Text)
+    post_date = storage.Column(storage.DateTime)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_article.py
+++ b/kokemomo/plugins/blog/model/km_blog_article.py
@@ -2,8 +2,7 @@
 # -*- coding:utf-8 -*-
 
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
-from sqlalchemy.types import Text
+from kokemomo.plugins.engine.controller.km_storage import db
 
 __author__ = 'hiroki'
 
@@ -20,22 +19,22 @@ It is blog article table to be used in the KOKEMOMO.
 
 """
 
-class KMBlogArticle(Base):
+
+class KMBlogArticle(db.Model):
     __tablename__ = 'km_blog_article'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    info_id = Column(Integer)
-    category_id = Column(Integer)
-    title = Column(Text)
-    article = Column(Text)
-    post_date = Column(DateTime)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    info_id = db.Column(db.Integer)
+    category_id = db.Column(db.Integer)
+    title = db.Column(db.Text)
+    article = db.Column(db.Text)
+    post_date = db.Column(db.DateTime)
 
     def __repr__(self):
         return create_repr_str(self)
 
     def get_json(self):
         return create_json(self)
+
 
 def create(id, session):
     if id == 'None':
@@ -49,18 +48,21 @@ def create(id, session):
         article = find(id, session)
     return article
 
+
 def find(id, session):
     result = None
     for article in session.query(KMBlogArticle).filter_by(id=id).all():
         result = article
     return result
 
+
 def find_by_info_id(info_id, session):
     result = []
-    fetch = session.query(KMBlogArticle).filter_by(info_id=info_id).all();
+    fetch = session.query(KMBlogArticle).filter_by(info_id=info_id).all()
     for article in fetch:
         result.append(article)
     return result
+
 
 def find_all(session):
     result = []
@@ -97,6 +99,7 @@ def delete(id, session):
         session.rollback()
         raise e
 
+
 def delete_by_info(info_id, session):
     fetch = session.query(KMBlogArticle).filter_by(info_id=info_id).all()
     try:
@@ -106,6 +109,7 @@ def delete_by_info(info_id, session):
     except Exception as e:
         session.rollback()
         raise e
+
 
 def delete_by_category(category_id, session):
     fetch = session.query(KMBlogArticle).filter_by(category_id=category_id).all()

--- a/kokemomo/plugins/blog/model/km_blog_category.py
+++ b/kokemomo/plugins/blog/model/km_blog_category.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 __author__ = 'hiroki'
 
@@ -17,11 +17,11 @@ It is blog category table to be used in the KOKEMOMO.
 """
 
 
-class KMBlogCategory(db.Model):
+class KMBlogCategory(storage.Model):
     __tablename__ = 'km_blog_category'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    info_id = db.Column(db.Integer)
-    name = db.Column(db.Text)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    info_id = storage.Column(storage.Integer)
+    name = storage.Column(storage.Text)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_category.py
+++ b/kokemomo/plugins/blog/model/km_blog_category.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
-from sqlalchemy.types import Text
+from kokemomo.plugins.engine.controller.km_storage import db
 
 __author__ = 'hiroki'
 
@@ -17,19 +16,19 @@ It is blog category table to be used in the KOKEMOMO.
 
 """
 
-class KMBlogCategory(Base):
+
+class KMBlogCategory(db.Model):
     __tablename__ = 'km_blog_category'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    info_id = Column(Integer)
-    name = Column(Text)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    info_id = db.Column(db.Integer)
+    name = db.Column(db.Text)
 
     def __repr__(self):
         return create_repr_str(self)
 
     def get_json(self):
         return create_json(self)
+
 
 def create(id, session):
     if id == 'None':
@@ -39,17 +38,20 @@ def create(id, session):
         category = find(id, session)
     return category
 
+
 def find(id, session):
     result = None
     for category in session.query(KMBlogCategory).filter_by(id=id).all():
         result = category
     return result
 
+
 def find_by_info(info_id, session):
     result = []
     for info in session.query(KMBlogCategory).filter_by(info_id=info_id).all():
         result.append(info)
     return result
+
 
 def find_all(session):
     result = []
@@ -85,6 +87,7 @@ def delete(id, session):
     except Exception as e:
         session.rollback()
         raise e
+
 
 def delete_by_info(info_id, session):
     fetch = session.query(KMBlogCategory).filter_by(info_id=info_id).all()

--- a/kokemomo/plugins/blog/model/km_blog_comment.py
+++ b/kokemomo/plugins/blog/model/km_blog_comment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 from sqlalchemy.types import Text
 
 __author__ = 'hiroki'
@@ -18,11 +18,11 @@ It is blog comment table to be used in the KOKEMOMO.
 """
 
 
-class KMBlogComment(db.Model):
+class KMBlogComment(storage.Model):
     __tablename__ = 'km_blog_comment'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    article_id = db.Column(db.Integer)
-    comment = db.Column(db.Text)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    article_id = storage.Column(storage.Integer)
+    comment = storage.Column(storage.Text)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_comment.py
+++ b/kokemomo/plugins/blog/model/km_blog_comment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 from sqlalchemy.types import Text
 
 __author__ = 'hiroki'
@@ -17,13 +17,12 @@ It is blog comment table to be used in the KOKEMOMO.
 
 """
 
-class KMBlogComment(Base):
+
+class KMBlogComment(db.Model):
     __tablename__ = 'km_blog_comment'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    article_id = Column(Integer)
-    comment = Column(Text)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    article_id = db.Column(db.Integer)
+    comment = db.Column(db.Text)
 
     def __repr__(self):
         return create_repr_str(self)
@@ -41,7 +40,7 @@ def find(id, session):
 
 def find_by_article_id(article_id, session):
     result = []
-    fetch = session.query(KMBlogComment).filter_by(article_id=article_id).all();
+    fetch = session.query(KMBlogComment).filter_by(article_id=article_id).all()
     for comment in fetch:
         result.append(comment)
     return result

--- a/kokemomo/plugins/blog/model/km_blog_info.py
+++ b/kokemomo/plugins/blog/model/km_blog_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 from sqlalchemy.types import Text
 
 __author__ = 'hiroki'
@@ -18,12 +18,12 @@ It is blog information table to be used in the Kokemomo.
 """
 
 
-class KMBlogInfo(db.Model):
+class KMBlogInfo(storage.Model):
     __tablename__ = 'km_blog_info'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    name = db.Column(db.Text)
-    url = db.Column(db.Text)
-    description = db.Column(db.Text)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    name = storage.Column(storage.Text)
+    url = storage.Column(storage.Text)
+    description = storage.Column(storage.Text)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_info.py
+++ b/kokemomo/plugins/blog/model/km_blog_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 from sqlalchemy.types import Text
 
 __author__ = 'hiroki'
@@ -17,20 +17,20 @@ It is blog information table to be used in the Kokemomo.
     update_at:DateTime(Automatic Updates)
 """
 
-class KMBlogInfo(Base):
+
+class KMBlogInfo(db.Model):
     __tablename__ = 'km_blog_info'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    name = Column(Text)
-    url = Column(Text)
-    description = Column(Text)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    name = db.Column(db.Text)
+    url = db.Column(db.Text)
+    description = db.Column(db.Text)
 
     def __repr__(self):
         return create_repr_str(self)
 
     def get_json(self):
         return create_json(self)
+
 
 def create(id, session):
     if id == 'None':
@@ -42,17 +42,20 @@ def create(id, session):
         info = find(id, session)
     return info
 
+
 def find(id, session):
     result = None
     for info in session.query(KMBlogInfo).filter_by(id=id).all():
         result = info
     return result
 
+
 def find_by_url(url, session):
     result = None
     for info in session.query(KMBlogInfo).filter_by(url=url).all():
         result = info
     return result
+
 
 def find_all(session):
     result = []

--- a/kokemomo/plugins/blog/model/km_blog_subscription.py
+++ b/kokemomo/plugins/blog/model/km_blog_subscription.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 __author__ = 'hiroki'
 
@@ -17,11 +17,11 @@ It is blog subscription table to be used in the KOKEMOMO.
 """
 
 
-class KMBlogSubscription(db.Model):
+class KMBlogSubscription(storage.Model):
     __tablename__ = 'km_blog_subscription'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    user_id = db.Column(db.Integer)
-    target_id = db.Column(db.Integer)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    user_id = storage.Column(storage.Integer)
+    target_id = storage.Column(storage.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/blog/model/km_blog_subscription.py
+++ b/kokemomo/plugins/blog/model/km_blog_subscription.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 
 __author__ = 'hiroki'
 
@@ -16,13 +16,12 @@ It is blog subscription table to be used in the KOKEMOMO.
 
 """
 
-class KMBlogSubscription(Base):
+
+class KMBlogSubscription(db.Model):
     __tablename__ = 'km_blog_subscription'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    user_id = Column(Integer)
-    target_id = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    user_id = db.Column(db.Integer)
+    target_id = db.Column(db.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/common_entry/controller/km_entry.py
+++ b/kokemomo/plugins/common_entry/controller/km_entry.py
@@ -5,7 +5,6 @@ import json
 from kokemomo.lib.bottle import template, route, static_file, url, request, response, redirect
 from kokemomo.plugins.common_entry.controller.km_entry_config import get_model, get_name, entry_model
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import *
 
 __author__ = 'hiroki'
 
@@ -18,7 +17,7 @@ Generates display items of model set, it is possible to register a value.
 -------------------------------------------------------------------
 """
 
-db_manager = KMDBManager("engine")
+from kokemomo.plugins.engine.controller.km_storage import db
 
 @route('/common_entry/js/<filename>', name='common_entry_static_js')
 def common_entry_js_static(filename):
@@ -76,6 +75,6 @@ def entry(request):
     """
     for entry_params in request.forms:
         model = set_value_list(get_model(), entry_params)
-        session = db_manager.get_session()
+        session = db.adapter.session
         entry_model(model, session)
         session.close()

--- a/kokemomo/plugins/common_entry/controller/km_entry.py
+++ b/kokemomo/plugins/common_entry/controller/km_entry.py
@@ -17,7 +17,7 @@ Generates display items of model set, it is possible to register a value.
 -------------------------------------------------------------------
 """
 
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 @route('/common_entry/js/<filename>', name='common_entry_static_js')
 def common_entry_js_static(filename):
@@ -75,6 +75,6 @@ def entry(request):
     """
     for entry_params in request.forms:
         model = set_value_list(get_model(), entry_params)
-        session = db.adapter.session
+        session = storage.adapter.session
         entry_model(model, session)
         session.close()

--- a/kokemomo/plugins/engine/controller/km_access_check.py
+++ b/kokemomo/plugins/engine/controller/km_access_check.py
@@ -7,7 +7,6 @@ from ..model.km_user_table import find as find_user
 from ..model.km_role_table import find as find_role
 from ..utils.km_config import get_character_set_setting
 from .km_session_manager import get_value_to_session
-from .km_db_manager import KMDBManager
 
 """
 Access check class for KOKEMOMO.
@@ -18,7 +17,7 @@ It provides as a decorator each check processing.
 
 __author__ = 'hiroki'
 
-db_manager = KMDBManager("engine")
+from kokemomo.plugins.engine.controller.km_storage import db
 
 
 def access_check(request):
@@ -33,7 +32,7 @@ def access_check(request):
             user_id = get_value_to_session(request, 'user_id')
             if user_id is not None:
                 try:
-                    session = db_manager.get_session()
+                    session = db.adapter.session
                     user = find_user(user_id, session)
                     user_id = user.id
                     role = find_role(user_id, session)

--- a/kokemomo/plugins/engine/controller/km_access_check.py
+++ b/kokemomo/plugins/engine/controller/km_access_check.py
@@ -17,7 +17,7 @@ It provides as a decorator each check processing.
 
 __author__ = 'hiroki'
 
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 
 def access_check(request):
@@ -32,7 +32,7 @@ def access_check(request):
             user_id = get_value_to_session(request, 'user_id')
             if user_id is not None:
                 try:
-                    session = db.adapter.session
+                    session = storage.adapter.session
                     user = find_user(user_id, session)
                     user_id = user.id
                     role = find_role(user_id, session)

--- a/kokemomo/plugins/engine/controller/km_login.py
+++ b/kokemomo/plugins/engine/controller/km_login.py
@@ -47,7 +47,7 @@ def login_auth(km_data, db_manager):
 def auth(request, db_manager, id, password):
     result = RESULT_FAIL
     try:
-        session = db_manager.get_session()
+        session = db_manager.adapter.session
         user = find(id, session)
         if user is not None:
             user_password = user.password

--- a/kokemomo/plugins/engine/controller/km_storage.py
+++ b/kokemomo/plugins/engine/controller/km_storage.py
@@ -1,0 +1,134 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, func
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from abc import ABCMeta, abstractmethod
+
+default_adapter = None
+
+
+class Storage(object):
+    def __init__(self, adapter=None):
+        if adapter is None:
+            self.adapter = default_adapter
+        else:
+            self.adapter = adapter
+
+        if self.adapter.fields:
+            for field in self.adapter.fields:
+                setattr(self, field.__name__, field)
+
+    def init(self, *args, **kwargs):
+        self.adapter.init(*args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        self.adapter.set(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self.adapter.get(*args, **kwargs)
+
+    @property
+    def Model(self):
+        return self.adapter.Model
+
+
+class BasicAdapter(object):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def init(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def set(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def get(self, *args, **kwargs):
+        pass
+
+
+class RdbAdapter(object):
+    __metaclass__ = ABCMeta
+
+
+class BaseModel(object):
+    id = Column(Integer, primary_key=True)
+    created_at = Column(DateTime, default=func.now())
+    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    @declared_attr
+    def __tablename__(cls):
+        return cls.__name__.lower()
+
+    def __repr__(self):
+        return '<%s>' % self.__class__.__name__
+
+    def save(self):
+        try:
+            db.adapter.add(self)
+            db.adapter.commit()
+        except:
+            db.adapter.rollback()
+            raise
+
+    def delete(self):
+        try:
+            db.adapter.add(self)
+            db.adapter.commit()
+        except:
+            db.adapter.rollback()
+            raise
+
+    @classmethod
+    def all(cls):
+        return db.session.query(cls)
+
+
+class SQLAlchemyAdapter(BasicAdapter, RdbAdapter):
+
+    def __init__(self, db_path):
+        self.session = scoped_session(sessionmaker())
+        self.engine = create_engine(db_path, echo=True)
+        self.Model = declarative_base(cls=BaseModel)
+        self.session.configure(bind=self.engine)
+
+        self.fields = [Column, String, Text, Integer, Boolean, DateTime]
+
+    @property
+    def metadata(self):
+        return self.Model.metadata
+
+    def init(self):
+        self.metadata.create_all(self.engine)
+
+    def drop_all(self):
+        self.metadata.drop_all(self.engine)
+
+    def add(self, *args, **kwargs):
+        self.session.add(*args, **kwargs)
+
+    def commit(self):
+        self.session.commit()
+
+    def set(self, *args, **kwargs):
+        self.add(*args, **kwargs)
+        self.commit()
+
+    def rollback(self):
+        self.session.rollback()
+
+    def get(self, *args, **kwargs):
+        pass
+
+from ..utils.km_config import get_database_setting
+
+
+sql_url = get_database_setting('engine')
+db = Storage(
+    adapter=SQLAlchemyAdapter(sql_url)
+)
+# file = Storage(adapter=FileAdapter('~/hoge.md')
+# redis = Storage(adapter=RedisAdapter())

--- a/kokemomo/plugins/engine/controller/km_storage/__init__.py
+++ b/kokemomo/plugins/engine/controller/km_storage/__init__.py
@@ -1,0 +1,71 @@
+
+from abc import ABCMeta, abstractmethod
+
+default_adapter = None
+
+
+class Storage(object):
+    def __init__(self, adapter=None):
+        if adapter is None:
+            self.adapter = default_adapter
+        else:
+            self.adapter = adapter
+
+        if self.adapter.fields:
+            for field in self.adapter.fields:
+                setattr(self, field.__name__, field)
+
+    def init(self, *args, **kwargs):
+        self.adapter.init(*args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        self.adapter.set(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self.adapter.get(*args, **kwargs)
+
+    @property
+    def Model(self):
+        return self.adapter.Model
+
+
+class BasicAdapter(object):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def init(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def set(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def get(self, *args, **kwargs):
+        pass
+
+
+class RdbAdapter(object):
+    __metaclass__ = ABCMeta
+
+
+from kokemomo.plugins.engine.utils.km_config import (
+    get_database_setting,
+    get_storage_adapter_setting
+)
+
+sql_url = get_database_setting('engine')
+adapter_name = get_storage_adapter_setting()
+adapter_filename = adapter_name.lower() + "_adapter"
+
+mod = __import__(
+    "kokemomo.plugins.engine.controller.km_storage.adapter",
+    fromlist=[adapter_filename])
+class_def = getattr(getattr(mod, adapter_filename), adapter_name+"Adapter")
+
+
+db = Storage(
+    adapter=class_def(sql_url)
+)
+
+__all__ = ['Storage', 'BasicAdapter', 'RdbAdapter', 'db']

--- a/kokemomo/plugins/engine/controller/km_storage/__init__.py
+++ b/kokemomo/plugins/engine/controller/km_storage/__init__.py
@@ -64,8 +64,8 @@ mod = __import__(
 class_def = getattr(getattr(mod, adapter_filename), adapter_name+"Adapter")
 
 
-db = Storage(
+storage = Storage(
     adapter=class_def(sql_url)
 )
 
-__all__ = ['Storage', 'BasicAdapter', 'RdbAdapter', 'db']
+__all__ = ['Storage', 'BasicAdapter', 'RdbAdapter', 'storage']

--- a/kokemomo/plugins/engine/controller/km_storage/adapter/__init__.py
+++ b/kokemomo/plugins/engine/controller/km_storage/adapter/__init__.py
@@ -1,0 +1,3 @@
+from .sqlalchemy_adapter import SQLAlchemyAdapter
+
+__all__ = ['SQLAlchemyAdapter']

--- a/kokemomo/plugins/engine/controller/km_storage/adapter/sqlalchemy_adapter.py
+++ b/kokemomo/plugins/engine/controller/km_storage/adapter/sqlalchemy_adapter.py
@@ -23,23 +23,23 @@ class BaseModel(object):
 
     def save(self):
         try:
-            db.adapter.add(self)
-            db.adapter.commit()
+            storage.adapter.add(self)
+            storage.adapter.commit()
         except:
-            db.adapter.rollback()
+            storage.adapter.rollback()
             raise
 
     def delete(self):
         try:
-            db.adapter.add(self)
-            db.adapter.commit()
+            storage.adapter.add(self)
+            storage.adapter.commit()
         except:
-            db.adapter.rollback()
+            storage.adapter.rollback()
             raise
 
     @classmethod
     def all(cls):
-        return db.session.query(cls)
+        return storage.session.query(cls)
 
 
 class SQLAlchemyAdapter(BasicAdapter, RdbAdapter):

--- a/kokemomo/plugins/engine/controller/km_storage/adapter/sqlalchemy_adapter.py
+++ b/kokemomo/plugins/engine/controller/km_storage/adapter/sqlalchemy_adapter.py
@@ -1,57 +1,12 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, func
+from sqlalchemy import (
+    Column, Integer, String, Text, DateTime, Boolean, func
+)
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from abc import ABCMeta, abstractmethod
-
-default_adapter = None
-
-
-class Storage(object):
-    def __init__(self, adapter=None):
-        if adapter is None:
-            self.adapter = default_adapter
-        else:
-            self.adapter = adapter
-
-        if self.adapter.fields:
-            for field in self.adapter.fields:
-                setattr(self, field.__name__, field)
-
-    def init(self, *args, **kwargs):
-        self.adapter.init(*args, **kwargs)
-
-    def set(self, *args, **kwargs):
-        self.adapter.set(*args, **kwargs)
-
-    def get(self, *args, **kwargs):
-        return self.adapter.get(*args, **kwargs)
-
-    @property
-    def Model(self):
-        return self.adapter.Model
-
-
-class BasicAdapter(object):
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def init(self, *args, **kwargs):
-        pass
-
-    @abstractmethod
-    def set(self, *args, **kwargs):
-        pass
-
-    @abstractmethod
-    def get(self, *args, **kwargs):
-        pass
-
-
-class RdbAdapter(object):
-    __metaclass__ = ABCMeta
+from kokemomo.plugins.engine.controller.km_storage import *
 
 
 class BaseModel(object):
@@ -122,13 +77,3 @@ class SQLAlchemyAdapter(BasicAdapter, RdbAdapter):
 
     def get(self, *args, **kwargs):
         pass
-
-from ..utils.km_config import get_database_setting
-
-
-sql_url = get_database_setting('engine')
-db = Storage(
-    adapter=SQLAlchemyAdapter(sql_url)
-)
-# file = Storage(adapter=FileAdapter('~/hoge.md')
-# redis = Storage(adapter=RedisAdapter())

--- a/kokemomo/plugins/engine/model/km_group_table.py
+++ b/kokemomo/plugins/engine/model/km_group_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 
 __author__ = 'hiroki'
 
@@ -29,13 +29,12 @@ def search_parameter():
 -------------------------------------------------------------------
 """
 
-class KMGroup(Base):
+
+class KMGroup(db.Model):
     __tablename__ = 'km_group'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    name = Column(String(50))
-    parent_id = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    name = db.Column(db.String(50))
+    parent_id = db.Column(db.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_group_table.py
+++ b/kokemomo/plugins/engine/model/km_group_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 __author__ = 'hiroki'
 
@@ -30,11 +30,11 @@ def search_parameter():
 """
 
 
-class KMGroup(db.Model):
+class KMGroup(storage.Model):
     __tablename__ = 'km_group'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    name = db.Column(db.String(50))
-    parent_id = db.Column(db.Integer)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    name = storage.Column(storage.String(50))
+    parent_id = storage.Column(storage.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_parameter_table.py
+++ b/kokemomo/plugins/engine/model/km_parameter_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 from sqlalchemy.types import Text
 
 """
@@ -28,13 +28,12 @@ def search_parameter():
 -------------------------------------------------------------------
 """
 
-class KMParameter(Base):
+
+class KMParameter(db.Model):
     __tablename__ = 'km_parameter'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    key = Column(String(50))
-    json = Column(Text())
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    key = db.Column(db.String(50))
+    json = db.Column(db.Text())
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_parameter_table.py
+++ b/kokemomo/plugins/engine/model/km_parameter_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 from sqlalchemy.types import Text
 
 """
@@ -29,11 +29,11 @@ def search_parameter():
 """
 
 
-class KMParameter(db.Model):
+class KMParameter(storage.Model):
     __tablename__ = 'km_parameter'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    key = db.Column(db.String(50))
-    json = db.Column(db.Text())
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    key = storage.Column(storage.String(50))
+    json = storage.Column(storage.Text())
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_role_table.py
+++ b/kokemomo/plugins/engine/model/km_role_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 from sqlalchemy.types import Boolean
 
 __author__ = 'hiroki'
@@ -32,12 +32,12 @@ def search_parameter():
 """
 
 
-class KMRole(db.Model):
+class KMRole(storage.Model):
     __tablename__ = 'km_role'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    name = db.Column(db.String(50))
-    target = db.Column(db.String(100))
-    is_allow = db.Column(db.Boolean)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    name = storage.Column(storage.String(50))
+    target = storage.Column(storage.String(100))
+    is_allow = storage.Column(storage.Boolean)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_role_table.py
+++ b/kokemomo/plugins/engine/model/km_role_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 from sqlalchemy.types import Boolean
 
 __author__ = 'hiroki'
@@ -31,14 +31,13 @@ def search_parameter():
 -------------------------------------------------------------------
 """
 
-class KMRole(Base):
+
+class KMRole(db.Model):
     __tablename__ = 'km_role'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    name = Column(String(50))
-    target = Column(String(100))
-    is_allow = Column(Boolean)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    name = db.Column(db.String(50))
+    target = db.Column(db.String(100))
+    is_allow = db.Column(db.Boolean)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_user_table.py
+++ b/kokemomo/plugins/engine/model/km_user_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 
 __author__ = 'hiroki'
 
@@ -34,15 +34,15 @@ def search_parameter():
 """
 
 
-class KMUser(db.Model):
+class KMUser(storage.Model):
     __tablename__ = 'km_user'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    user_id = db.Column(db.String(20))
-    name = db.Column(db.String(50))
-    password = db.Column(db.String(20))
-    mail_address = db.Column(db.String(254))
-    group_id = db.Column(db.Integer)
-    role_id = db.Column(db.Integer)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    user_id = storage.Column(storage.String(20))
+    name = storage.Column(storage.String(50))
+    password = storage.Column(storage.String(20))
+    mail_address = storage.Column(storage.String(254))
+    group_id = storage.Column(storage.Integer)
+    role_id = storage.Column(storage.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/model/km_user_table.py
+++ b/kokemomo/plugins/engine/model/km_user_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 
 __author__ = 'hiroki'
 
@@ -33,17 +33,16 @@ def search_parameter():
 -------------------------------------------------------------------
 """
 
-class KMUser(Base):
+
+class KMUser(db.Model):
     __tablename__ = 'km_user'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    user_id = Column(String(20))
-    name = Column(String(50))
-    password = Column(String(20))
-    mail_address = Column(String(254))
-    group_id = Column(Integer)
-    role_id = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    user_id = db.Column(db.String(20))
+    name = db.Column(db.String(50))
+    password = db.Column(db.String(20))
+    mail_address = db.Column(db.String(254))
+    group_id = db.Column(db.Integer)
+    role_id = db.Column(db.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/engine/utils/km_config.py
+++ b/kokemomo/plugins/engine/utils/km_config.py
@@ -189,3 +189,25 @@ def get_wsgi_setting():
                             name = config.get(section, option)
                     __config_data[section_name] = name
     return __config_data[section_name]
+
+
+def get_storage_adapter_setting():
+    '''
+    get adapter setting.
+    :return: config object.
+    '''
+    section_name = 'Storage_Adapter'
+    if section_name in __config_data:
+        return __config_data[section_name]
+    else:
+        ini_file_path = os.path.abspath(os.curdir) + '/setting/kokemomo.ini'
+        if os.path.exists(ini_file_path):
+            config = ConfigParser.SafeConfigParser()
+            config.read(ini_file_path)
+            for section in config.sections():
+                if section == section_name:
+                    for option in config.options(section):
+                        if option == 'name':
+                            name = config.get(section, option)
+                    __config_data[section_name] = name
+    return __config_data[section_name]

--- a/kokemomo/plugins/recommend/controller/km_recommend.py
+++ b/kokemomo/plugins/recommend/controller/km_recommend.py
@@ -6,7 +6,6 @@ __author__ = 'hiroki'
 import sys
 
 from kokemomo.plugins.recommend.model.km_history_table import find, find_list, update
-from kokemomo.plugins.engine.controller.km_db_manager import *
 from kokemomo.plugins.engine.utils.km_config import get_character_set_setting
 
 """
@@ -46,7 +45,7 @@ user01 is similar!
 
 """
 
-db_manager = KMDBManager("engine")
+from kokemomo.plugins.engine.controller.km_storage import db
 charset = get_character_set_setting()
 
 def get_recommend(user_id, columns, session):

--- a/kokemomo/plugins/recommend/controller/km_recommend.py
+++ b/kokemomo/plugins/recommend/controller/km_recommend.py
@@ -45,7 +45,7 @@ user01 is similar!
 
 """
 
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 charset = get_character_set_setting()
 
 def get_recommend(user_id, columns, session):

--- a/kokemomo/plugins/recommend/model/km_history_table.py
+++ b/kokemomo/plugins/recommend/model/km_history_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_storage import db
+from kokemomo.plugins.engine.controller.km_storage import storage
 from sqlalchemy.types import Text
 
 __author__ = 'hiroki'
@@ -32,12 +32,12 @@ def search_parameter():
 """
 
 
-class KMHistory(db.Model):
+class KMHistory(storage.Model):
     __tablename__ = 'km_history'
-    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
-    user_id = db.Column(db.String(10))
-    contents = db.Column(db.Text())
-    count = db.Column(db.Integer)
+    id = storage.Column(storage.Integer, autoincrement=True, primary_key=True)
+    user_id = storage.Column(storage.String(10))
+    contents = storage.Column(storage.Text())
+    count = storage.Column(storage.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/kokemomo/plugins/recommend/model/km_history_table.py
+++ b/kokemomo/plugins/recommend/model/km_history_table.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 from kokemomo.plugins.engine.utils.km_model_utils import *
-from kokemomo.plugins.engine.controller.km_db_manager import Base
+from kokemomo.plugins.engine.controller.km_storage import db
 from sqlalchemy.types import Text
 
 __author__ = 'hiroki'
@@ -31,14 +31,13 @@ def search_parameter():
 -------------------------------------------------------------------
 """
 
-class KMHistory(Base):
+
+class KMHistory(db.Model):
     __tablename__ = 'km_history'
-    id = Column(Integer, autoincrement=True, primary_key=True)
-    user_id = Column(String(10))
-    contents = Column(Text())
-    count = Column(Integer)
-    create_at = Column(DateTime, default=datetime.datetime.now)
-    update_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    id = db.Column(db.Integer, autoincrement=True, primary_key=True)
+    user_id = db.Column(db.String(10))
+    contents = db.Column(db.Text())
+    count = db.Column(db.Integer)
 
     def __repr__(self):
         return create_repr_str(self)

--- a/setting/kokemomo.ini
+++ b/setting/kokemomo.ini
@@ -41,3 +41,7 @@ test_login=true
 
 [WSGI]
 name=Bottle
+
+[Storage_Adapter]
+name=SQLAlchemy
+


### PR DESCRIPTION
この変更では、新しいマネージャーを導入することにとどめ、出来る限り既存のコードはいじらないようにしています。
モデルインスタンスを保存する方法の改良は、今後反映させるつもりです。

```
db_manager = KMDBManager("engine")
```
を新しく作った `db`
```
db = Storage(adapter=SQLAlchemyAdapter(sql_url))
```
で置き換えます。

今までのコードでは`db_manager`を使いたい時に生成するような形式でしたが、本コードでは
```
from kokemomo.plugins.engine.controller.km_storage import db
```
として呼び出すだけで使用できるようになっています。

また、モデルのベースとなるクラスを用意し
`create_at` と `update_at` をモデルごとに書かなくても大丈夫にしました。

レビューよろしくお願いします:bow:
改善案を頂けたら、このプルリク上にコミットを追加して修正していくつもりです。

--

`Storage` クラスのアダプターにはFile型やMemcached、Redisなどを想定しています。